### PR TITLE
Use gist.githubusercontent.com directly, and serve jquery over https

### DIFF
--- a/404.html
+++ b/404.html
@@ -390,12 +390,12 @@ Slideshow created using [remark](http://github.com/gnab/remark) and host on [gis
     </textarea>
     <script src="//gnab.github.io/remark/downloads/remark-latest.min.js">
     </script>
-    <script src="http://code.jquery.com/jquery-2.1.0.min.js"></script>
+    <script src="//code.jquery.com/jquery-2.1.0.min.js"></script>
     <script>
      var path = window.location.pathname;
      if(path.split('/').length>2){
-       $.getJSON('http://gist.github.com.ru/jcouyang/a17746e54b0d480d7fb5?path=' + path + "&callback=?", function(data){
-         $('#source').html(data.result)
+       $.get('https://gist.githubusercontent.com/' + path + "/raw", function(data){
+         $('#source').html(data)
          remark.create({
            highlightStyle: 'monokai'
          });

--- a/index.html
+++ b/index.html
@@ -390,12 +390,12 @@ Slideshow created using [remark](http://github.com/gnab/remark) and host on [gis
     </textarea>
     <script src="//gnab.github.io/remark/downloads/remark-latest.min.js">
     </script>
-    <script src="http://code.jquery.com/jquery-2.1.0.min.js"></script>
+    <script src="//code.jquery.com/jquery-2.1.0.min.js"></script>
     <script>
      var path = window.location.pathname;
      if(path.split('/').length>2){
-       $.getJSON('http://gist.github.com.ru/jcouyang/a17746e54b0d480d7fb5?path=' + path + "&callback=?", function(data){
-         $('#source').html(data.result)
+       $.get('https://gist.githubusercontent.com/' + path + "/raw", function(data){
+         $('#source').html(data)
          remark.create({
            highlightStyle: 'monokai'
          });


### PR DESCRIPTION
Do not use the `gist.github.com.ru` domain to fetch the raw gist from `gist.githubusercontent.com`(GHU), but use GHU directly in the browser. (Saves 66% of total bandwith and 100% of `gist.github.com.ru` bandwidth.)
This works perfectly in all modern browsers because they support [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS), and GHU sets the allowed origins to all.

Also, jQuery gets served over https if the page gets served over https.
